### PR TITLE
Update plugin to work with new worker API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# Editor Stuff
+*~
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+.vscode/*
+.idea/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/receptor_sleep/worker.py
+++ b/receptor_sleep/worker.py
@@ -1,36 +1,8 @@
-import asyncio
 import json
 import logging
+import time
 
 logger = logging.getLogger(__name__)
-
-
-class ResponseQueue(asyncio.Queue):
-
-    def __init__(self, *args, **kwargs):
-        self.done = False
-        super().__init__(*args, **kwargs)
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        if self.done:
-            raise StopAsyncIteration
-        return await self.get()
-
-
-async def request(queue, duration, repeat):
-    idx = 0
-    while idx < repeat:
-        logger.debug(
-            f"Going to sleep for {duration} seconds, "
-            f"iteration {idx + 1} of {repeat})"
-        )
-        await asyncio.sleep(duration)
-        idx += 1
-        await queue.put("iteration {}".format(idx))
-    queue.done = True
 
 
 def configure_logger():
@@ -40,17 +12,25 @@ def configure_logger():
         logger.addHandler(handler)
 
 
-def execute(message, config):
+def execute(message, config, result_queue):
     configure_logger()
-    loop = asyncio.get_event_loop()
-    queue = ResponseQueue(loop=loop)
     try:
         payload = json.loads(message.raw_payload)
     except json.JSONDecodeError as err:
         logger.exception(err)
         raise
     logger.debug(f"Parsed payload: {payload}")
-    loop.create_task(request(queue,
-                             payload.pop("duration", 30),
-                             payload.pop("repeat", 1)))
-    return queue
+
+    duration = payload.pop("duration", 30)
+    repeat = payload.pop("repeat", 1)
+    ident = payload.pop("ident", "No ID")
+
+    idx = 0
+    while idx < repeat:
+        logger.debug(
+            f"Going to sleep for {duration} seconds, "
+            f"iteration {idx + 1} of {repeat})"
+        )
+        time.sleep(duration)
+        idx += 1
+        result_queue.put("{}: iteration {}".format(ident, idx))

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'requests',
     ],
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
This updates the plugin to reflect the changes in https://github.com/project-receptor/receptor/pull/128.  Instead of using an asyncio queue, the plugin runs in its own thread and gets a regular Python thread-safe queue to put responses on.