### PR TITLE
Mark receptor-callable worker method as exportable

### DIFF
--- a/receptor_sleep/worker.py
+++ b/receptor_sleep/worker.py
@@ -11,7 +11,11 @@ def configure_logger():
     for handler in receptor_logger.handlers:
         logger.addHandler(handler)
 
+def receptor_export(func):
+    setattr(func, "receptor_export", True)
+    return func
 
+@receptor_export
 def execute(message, config, result_queue):
     configure_logger()
     try:


### PR DESCRIPTION
Flag the receptor-callable method so receptor's work.py knows which one it's supposed to be allowed to call.  See https://github.com/project-receptor/receptor/pull/128/commits/f109f9e92f5562c95b7e435f77f1bb78edaad2bb